### PR TITLE
preamble and blame tweaks

### DIFF
--- a/laml.css
+++ b/laml.css
@@ -34,6 +34,9 @@ figure {
   font-style: italic;
   margin-top: 0;
 }
+#preamble {
+  display: none;
+}
 .abstract {
   font-size: 0.9em;
   font-style: italic;
@@ -44,11 +47,11 @@ figure {
   display: inline-block;
   font-weight: lighter;
 }
-.blame:before {
+.blame::before {
   display: inline;
   content: '\2005(';
 }
-.blame:after {
+.blame::after {
   display: inline;
   content: ')';
 }

--- a/laml.js
+++ b/laml.js
@@ -67,6 +67,12 @@ licensing.classList.add('license');
 licensing.innerHTML = 'Derived from <a href="' + articleMeta.source + '">' + articleMeta.source + '</a>, ' + articleMeta.license + ' and licensed as such.'
 articleInfo.appendChild(licensing);
 
+// preamble
+
+const preamble = document.querySelector('preamble');
+const newpreamble = renameTag(preamble, 'div');
+newpreamble.id = 'preamble';
+
 // abstract
 
 const abstract = document.querySelector('abstract');
@@ -92,12 +98,6 @@ for (let statement of statements) {
   heading.innerHTML =
     tagname[0].toUpperCase() + tagname.substring(1) + ' ' + statement_counter;
   renamedNode.insertBefore(heading, renamedNode.firstChild);
-  const blame = renamedNode.querySelector('blame');
-  if (blame) {
-    const newBlame = renameTag(blame, 'span');
-    newBlame.classList.add('blame');
-    heading.appendChild(newBlame);
-  }
 }
 
 // handle figures
@@ -121,6 +121,13 @@ for (let name of names) {
   // TODO look up correct heading level
   const renamedNode = renameTag(name, 'h2');
   renamedNode.classList.add('name');
+}
+
+// convert blames to spans
+const blames = document.querySelectorAll('blame');
+for (let blame of blames) {
+  const renamedNode = renameTag(blame, 'span');
+  renamedNode.classList.add('blame');
 }
 
 // convert ref to links

--- a/vatter.html
+++ b/vatter.html
@@ -30,9 +30,16 @@
 <!-- <link rel="stylesheet" href="https://cdn.concisecss.com/concise.min.css"> -->
 <link rel="stylesheet" href="laml.css">
 <link rel="stylesheet" href="cm.css">
-<div style="display:none">
-\[\newcommand{\Av}{\operatorname{Av}}\newcommand{\Grid}{\operatorname{Grid}}\newcommand{\C}{\mathcal{C}}\newcommand{\D}{\mathcal{D}}\newcommand{\st}{\::\:}\]
-</div>
+
+<preamble>
+\[
+\newcommand{\Av}{\operatorname{Av}}
+\newcommand{\Grid}{\operatorname{Grid}}
+\newcommand{\C}{\mathcal{C}}
+\newcommand{\D}{\mathcal{D}}
+\newcommand{\st}{\::\:}
+\]
+</preamble>
 
 <abstract>
   Let $\mathcal{C}$ be a permutation class that does not contain all layered permutations or all colayered permutations. We prove that every permutation in $\mathcal{C}$ contains a monotone subsequence of linear size.
@@ -41,14 +48,16 @@
 Ramsey's Theorem tells us that every graph on $n$ vertices has a clique or independent set of size at least a constant times $\log n$. In 1989, Erdős and Hajnal conjectured that one can do much better when avoiding a fixed induced subgraph:
 
 <theorem id=erdos-hajnal-conjecture>
-  <name>The Erdős–Hajnal Conjecture <cite target="erdos_ramsey-type-the"></cite>.</name>
+  <name>The Erdős–Hajnal Conjecture</name>
+  <blame><cite target="erdos_ramsey-type-the"></blame>
   For every graph $H$ there is a constant $\delta\ge0$ such that every graph on $n$ vertices which does not contain $H$ as an induced subgraph has a clique or independent set of size at least $n^\delta$.
 </theorem>
 
 We refer to Chudnovsky's survey <cite target="chudnovsky_the-erdos--hajn"></cite> for an account of the progress that has been made toward the Erdős–Hajnal Conjecture. Here we investigate a version of this conjecture for permutations. In this context, the analogue of the induced subgraph order is the permutation pattern order and the analogues of cliques and independent sets are decreasing and increasing subsequences, respectively. Thus the naive translation of the Erdős–Hajnal Conjecture to permutations is well known to hold with $\delta=1/2$:
 
 <theorem id=erdos-szekeres-theorem>
-  <name>The Erdős–Szekeres Theorem <cite target="erdos_a-combinatorial"></cite></name>
+  <name>The Erdős–Szekeres Theorem</name>
+  <blame><cite target="erdos_a-combinatorial"></cite></blame>
   Every permutation of length at least $(k-1)(\ell-1)+1$ contains either a decreasing subsequence of length $k$ or an an increasing subsequence of length $\ell$.
 </theorem>
 


### PR DESCRIPTION
create a preamble tag, move blame code so both name and blame can be used